### PR TITLE
Use claude instead of gpt5

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Ultralytics Actions
-        uses: ultralytics/actions@main
+        uses: ultralytics/actions@feature/anthropic-claude-support
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI
@@ -33,5 +33,6 @@ jobs:
           links: false # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           review: true # PR reviews
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }} # Powers PR summaries, labels and comments
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Updated the Ultralytics Actions version to support Anthropic Claude features, enhancing AI capabilities in PR summaries and reviews.